### PR TITLE
Updated .show-for-small to support Gmail 

### DIFF
--- a/css/ink.css
+++ b/css/ink.css
@@ -315,8 +315,14 @@ img.center {
 .show-for-small,
 .hide-for-desktop {
   display: none;
-  width:0; 
+  width:0;
+  mso-hide:all;
   overflow:hidden;
+}
+
+.show-for-small *,
+.hide-for-desktop * {
+	mso-hide:all;
 }
 
 /* Typography */

--- a/css/ink.css
+++ b/css/ink.css
@@ -315,6 +315,8 @@ img.center {
 .show-for-small,
 .hide-for-desktop {
   display: none;
+  width:0; 
+  overflow:hidden;
 }
 
 /* Typography */
@@ -689,6 +691,8 @@ body.outlook p {
 
   table[class="body"] .show-for-small,
   table[class="body"] .hide-for-desktop {
-    display: inherit !important;
+    display : block !important;
+    width : auto !important;
+    overflow : visible !important;
   }
 }


### PR DESCRIPTION
Based on several Stackoverflow answers I added support for .show-for-small. It hides an element on desktop clients, including Gmail and Outlook. And displays the content on mobile devices. 

There is one downside. In Gmail, the hidden element maintains it's vertical space, so you're left with whitespace in place of the element.

To use .show-for-small you would wrap the element in 

`<div class="show-for-small">Hidden content</div>`