### PR TITLE
Replace 3 character hex color codes with 6 character codes.

### DIFF
--- a/css/ink.css
+++ b/css/ink.css
@@ -496,7 +496,7 @@ table.button:active td {
 table.button:hover td a,
 table.button:visited td a,
 table.button:active td a {
-  color: #fff !important;
+  color: #ffffff !important;
 }
 
 table.button:hover td,
@@ -528,22 +528,22 @@ table.large-button td a:visited {
 table.secondary td {
   background: #e9e9e9;
   border-color: #d0d0d0;
-  color: #555;
+  color: #555555;
 }
 
 table.secondary td a {
-  color: #555;
+  color: #555555;
 }
 
 table.secondary:hover td {
   background: #d0d0d0 !important;
-  color: #555;
+  color: #555555;
 }
 
 table.secondary:hover td a,
 table.secondary td a:visited,
 table.secondary:active td a {
-  color: #555 !important;
+  color: #555555 !important;
 }
 
 table.success td {


### PR DESCRIPTION
Replace shorthand three character hexadecimal color codes with full six character hexadecimal codes as recommended in the following sources:

* Zurb's [Responsive Email Gotchas to Avoid](http://zurb.com/university/library/23)
* Litmus' [The Best Way to Code Background Colors for HTML Email](https://litmus.com/blog/background-colors-html-email)
* Campaign Monitor's [Email Design Guidelines](http://www.campaignmonitor.com/resources/will-it-work/guidelines/)
* Campaign Monitor's [Outlook 2013 doesn’t respect height in empty table cells](http://www.campaignmonitor.com/blog/post/3795/outlook-2013-says-no-to-empty-table-cells)

*Litmus Tests*
* [Basic](https://litmus.com/pub/9fd5b02)
* [Hero](https://litmus.com/pub/eb24004)
* [Hero Sidebar](https://litmus.com/pub/77e099d)
* [Sidebar](https://litmus.com/pub/e512618)