### PR TITLE
Fix invalid CSS option for word-break property

### DIFF
--- a/css/ink.css
+++ b/css/ink.css
@@ -69,7 +69,7 @@ table {
 }
 
 td { 
-  word-break: break-word;
+  word-wrap: break-word;
   -webkit-hyphens: auto;
   -moz-hyphens: auto;
   hyphens: auto;


### PR DESCRIPTION
`break-word` is not a valid option for the CSS property `word-break`. However, it is valid for the property `word-wrap`.