### PR TITLE
Change hyphen property

### DIFF
--- a/css/ink.css
+++ b/css/ink.css
@@ -70,9 +70,9 @@ table {
 
 td {
   word-break: break-word;
-  -webkit-hyphens: auto;
-  -moz-hyphens: auto;
-  hyphens: auto;
+  -webkit-hyphens: none;
+  -moz-hyphens: none;
+  hyphens: none;
   border-collapse: collapse !important;
 }
 


### PR DESCRIPTION
Causes a multitude of unnecessary word breaks in Apple Mail/iOS mail app and is ignored in every other client causing inconsistency. Google Chrome has no support for the hyphen property in any version.