### PR TITLE
Change the button padding from the `td` tag to the `a` tag

### DIFF
--- a/css/ink.css
+++ b/css/ink.css
@@ -436,23 +436,7 @@ table.large-button td {
   background: #2ba6cb;
   border: 1px solid #2284a1;
   color: #ffffff;
-  padding: 8px 0;
-}
-
-table.tiny-button td {
-  padding: 5px 0 4px;
-}
-
-table.small-button td {
-  padding: 8px 0 7px;
-}
-
-table.medium-button td {
-  padding: 12px 0 10px;
-}
-
-table.large-button td {
-  padding: 21px 0 18px;
+  padding: 0;
 }
 
 table.button td a,
@@ -468,6 +452,23 @@ table.large-button td a {
   display: block;
   height: 100%;
   width: 100%;
+  padding: 8px 0 6px;
+}
+
+table.tiny-button td a {
+  padding: 5px 0 3px;
+}
+
+table.small-button td a {
+  padding: 8px 0 6px;
+}
+
+table.medium-button td a {
+  padding: 12px 0 10px;
+}
+
+table.large-button td a {
+  padding: 21px 0 18px;
 }
 
 table.tiny-button td a {

--- a/docs/components/buttons.php
+++ b/docs/components/buttons.php
@@ -70,7 +70,7 @@
 </table>
 <hr />
 <h2 class="light">Examples</h2>
-<p>Buttons expand to the width of their parent container by default, so it's recommended that you contain them within a sub-grid or a relatively small number of columns on the main grid.</p>
+<p>Buttons expand to the width of their parent container by default, so it's recommended that you contain them within a sub-grid or a relatively small number of columns on the main grid. It is also recommended that the button text is contained within an <code>&lt;a&gt;</code> tag.</p>
 <h6>Button Demo</h6>
 <p>All the button modifiers demonstrated. The rows of buttons are contained to <code>.four.columns</code> or <code>.six.columns</code> sections of the grid for clarity.</p>
 <iframe id="if-buttons" src="docs/examples/buttons.html"></iframe>
@@ -86,7 +86,7 @@
       <a href="#" class="reveal-table">Toggle Full Table</a>
     </div>
   </div>
-  
+
   <div class="row">
     <div class="small-12 columns">
       <table>


### PR DESCRIPTION
**Why?**
* This way, the user can click on the entire button block instead of just the text.
* It was confusing because the hover state was on the `td`. But when you clicked, nothing happened. You needed to click on the content within the actual `a` tag to go to the link.

It looks like padding doesn't need to be set on the `td` tag, the `a` tag should achieve the same thing -- via this [CSS](https://www.campaignmonitor.com/css/) chart. Also screenshot'd below.

![screen shot 2015-02-05 at 5 58 28 pm](https://cloud.githubusercontent.com/assets/1226984/6071137/a210b904-ad60-11e4-91e0-fc595d52ac67.png)
